### PR TITLE
Feature/is author flag

### DIFF
--- a/concept/model.go
+++ b/concept/model.go
@@ -18,6 +18,7 @@ type ConcordedConcept struct {
 	ParentUUIDs           []string     `json:"parentUUIDs,omitempty"`
 	BroaderUUIDs          []string     `json:"broaderUUIDs,omitempty"`
 	RelatedUUIDs          []string     `json:"relatedUUIDs,omitempty"`
+	IsAuthor              bool         `json:"isAuthor,omitempty"`
 	SourceRepresentations []s3.Concept `json:"sourceRepresentations,omitempty"`
 }
 

--- a/concept/service.go
+++ b/concept/service.go
@@ -196,6 +196,7 @@ func mergeCanonicalInformation(c ConcordedConcept, s s3.Concept) ConcordedConcep
 	c.TwitterHandle = s.TwitterHandle
 	c.ScopeNote = s.ScopeNote
 	c.ShortLabel = s.ShortLabel
+	c.IsAuthor = s.IsAuthor
 	c.ParentUUIDs = s.ParentUUIDs
 	c.BroaderUUIDs = s.BroaderUUIDs
 	c.RelatedUUIDs = s.RelatedUUIDs

--- a/concept/service.go
+++ b/concept/service.go
@@ -218,11 +218,11 @@ func sendToWriter(client httpClient, baseUrl string, urlParam string, conceptUUI
 	}
 	request.ContentLength = -1
 	request.Header.Set("X-Request-Id", tid)
-
 	resp, reqErr := client.Do(request)
+
 	defer resp.Body.Close()
 
-	if strings.Contains(baseUrl, "neo4j") {
+	if strings.Contains(baseUrl, "neo4j") && int(resp.StatusCode/100) == 2 {
 		dec := json.NewDecoder(resp.Body)
 		err = dec.Decode(&updatedConcepts)
 		if err != nil {

--- a/s3/model.go
+++ b/s3/model.go
@@ -18,4 +18,5 @@ type Concept struct {
 	TwitterHandle  string   `json:"twitterHandle,omitempty"`
 	ScopeNote      string   `json:"scopeNote,omitempty"`
 	ShortLabel     string   `json:"shortLabel,omitempty"`
+	IsAuthor       bool     `json:"isAuthor,omitempty"`
 }


### PR DESCRIPTION
The field `isAuthor` is passed from the source representation into the canonical view.  This is intended for use within Elasticsearch only and requires a TME source representation.