### PR TITLE
Added isAuthor flag into output

### DIFF
--- a/concept/model.go
+++ b/concept/model.go
@@ -18,6 +18,7 @@ type ConcordedConcept struct {
 	ParentUUIDs           []string     `json:"parentUUIDs,omitempty"`
 	BroaderUUIDs          []string     `json:"broaderUUIDs,omitempty"`
 	RelatedUUIDs          []string     `json:"relatedUUIDs,omitempty"`
+	IsAuthor              bool         `json:"isAuthor,omitempty"`
 	SourceRepresentations []s3.Concept `json:"sourceRepresentations,omitempty"`
 }
 

--- a/concept/service.go
+++ b/concept/service.go
@@ -196,7 +196,9 @@ func mergeCanonicalInformation(c ConcordedConcept, s s3.Concept) ConcordedConcep
 	c.TwitterHandle = s.TwitterHandle
 	c.ScopeNote = s.ScopeNote
 	c.ShortLabel = s.ShortLabel
-	c.IsAuthor = s.IsAuthor
+	if s.IsAuthor {
+		c.IsAuthor = s.IsAuthor
+	}
 	c.ParentUUIDs = s.ParentUUIDs
 	c.BroaderUUIDs = s.BroaderUUIDs
 	c.RelatedUUIDs = s.RelatedUUIDs

--- a/concept/service.go
+++ b/concept/service.go
@@ -196,6 +196,7 @@ func mergeCanonicalInformation(c ConcordedConcept, s s3.Concept) ConcordedConcep
 	c.TwitterHandle = s.TwitterHandle
 	c.ScopeNote = s.ScopeNote
 	c.ShortLabel = s.ShortLabel
+	c.IsAuthor = s.IsAuthor
 	c.ParentUUIDs = s.ParentUUIDs
 	c.BroaderUUIDs = s.BroaderUUIDs
 	c.RelatedUUIDs = s.RelatedUUIDs

--- a/s3/model.go
+++ b/s3/model.go
@@ -18,4 +18,5 @@ type Concept struct {
 	TwitterHandle  string   `json:"twitterHandle,omitempty"`
 	ScopeNote      string   `json:"scopeNote,omitempty"`
 	ShortLabel     string   `json:"shortLabel,omitempty"`
+	IsAuthor       bool     `json:"isAuthor,omitempty"`
 }


### PR DESCRIPTION
The field `isAuthor` is passed from the source representation into the canonical view. This is intended for use within Elasticsearch only and requires a TME source representation.