### PR TITLE
Feature/uppsf 1943 org industry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # This repo is owned by the universal-publishing team, which is  administered by the FT Content Programme Team.
 * @Financial-Times/universal-publishing
+
+# This repo is supported by the metadata team.
+* @Financial-Times/metadata-team

--- a/concept/model.go
+++ b/concept/model.go
@@ -10,6 +10,11 @@ type MembershipRole struct {
 	TerminationDate string `json:"terminationDate,omitempty"`
 }
 
+type NAICSIndustryClassification struct {
+	UUID string `json:"uuid,omitempty"`
+	Rank int    `json:"rank,omitempty"`
+}
+
 type ConcordedConcept struct {
 	// Required fields
 	PrefUUID  string `json:"prefUUID,omitempty"`
@@ -43,18 +48,19 @@ type ConcordedConcept struct {
 	PersonUUID       string           `json:"personUUID,omitempty"`
 	TerminationDate  string           `json:"terminationDate,omitempty"`
 	// Organisation
-	CountryCode            string   `json:"countryCode,omitempty"`
-	CountryOfRisk          string   `json:"countryOfRisk,omitempty"`
-	CountryOfIncorporation string   `json:"countryOfIncorporation,omitempty"`
-	CountryOfOperations    string   `json:"countryOfOperations,omitempty"`
-	FormerNames            []string `json:"formerNames,omitempty"`
-	TradeNames             []string `json:"tradeNames,omitempty"`
-	LeiCode                string   `json:"leiCode,omitempty"`
-	PostalCode             string   `json:"postalCode,omitempty"`
-	ProperName             string   `json:"properName,omitempty"`
-	ShortName              string   `json:"shortName,omitempty"`
-	YearFounded            int      `json:"yearFounded,omitempty"`
-	IsDeprecated           bool     `json:"isDeprecated,omitempty"`
+	CountryCode                  string                        `json:"countryCode,omitempty"`
+	CountryOfRisk                string                        `json:"countryOfRisk,omitempty"`
+	CountryOfIncorporation       string                        `json:"countryOfIncorporation,omitempty"`
+	CountryOfOperations          string                        `json:"countryOfOperations,omitempty"`
+	FormerNames                  []string                      `json:"formerNames,omitempty"`
+	TradeNames                   []string                      `json:"tradeNames,omitempty"`
+	LeiCode                      string                        `json:"leiCode,omitempty"`
+	PostalCode                   string                        `json:"postalCode,omitempty"`
+	ProperName                   string                        `json:"properName,omitempty"`
+	ShortName                    string                        `json:"shortName,omitempty"`
+	YearFounded                  int                           `json:"yearFounded,omitempty"`
+	IsDeprecated                 bool                          `json:"isDeprecated,omitempty"`
+	NAICSIndustryClassifications []NAICSIndustryClassification `json:"naicsIndustryClassifications,omitempty"`
 	// Location
 	ISO31661 string `json:"iso31661,omitempty"`
 	// IndustryClassification

--- a/concept/service.go
+++ b/concept/service.go
@@ -581,6 +581,14 @@ func mergeCanonicalInformation(c ConcordedConcept, s s3.Concept, scopeNoteOption
 			TerminationDate: mr.TerminationDate,
 		})
 	}
+
+	for _, ic := range s.NAICSIndustryClassifications {
+		c.NAICSIndustryClassifications = append(c.NAICSIndustryClassifications, NAICSIndustryClassification{
+			UUID: ic.UUID,
+			Rank: ic.Rank,
+		})
+	}
+
 	if s.OrganisationUUID != "" {
 		c.OrganisationUUID = s.OrganisationUUID
 	}

--- a/concept/service_test.go
+++ b/concept/service_test.go
@@ -719,6 +719,78 @@ func TestAggregateService_GetConcordedConcept_PublicCompany(t *testing.T) {
 	assert.Equal(t, expectedConcept, c)
 }
 
+func TestAggregateService_GetConcordedConcept_PublicCompany_WithNAICSCodes(t *testing.T) {
+	svc, _, _, _, _, _, _ := setupTestService(200, payload)
+	expectedConcept := ConcordedConcept{
+		PrefUUID:  "Organisation_WithNAICSCodes_Smartlogic_UUID",
+		Type:      "PublicCompany",
+		PrefLabel: "Apple, Inc.",
+		Aliases: []string{
+			"Apple, Inc.",
+		},
+		NAICSIndustryClassifications: []NAICSIndustryClassification{
+			{
+				UUID: "25c3be2a-15e0-434e-aaa9-ca067e70ae11",
+				Rank: 1,
+			},
+			{
+				UUID: "c9cae3ee-a804-4001-8046-02e714e1fa5b",
+				Rank: 2,
+			},
+			{
+				UUID: "7f0134c1-606a-4d12-a455-661cc4b0bfac",
+				Rank: 3,
+			},
+			{
+				UUID: "c35b851c-d185-40bd-967c-2403084920b3",
+				Rank: 4,
+			},
+		},
+		SourceRepresentations: []s3.Concept{
+			{
+				UUID:      "Organisation_WithNAICSCodes_Factset_UUID",
+				Type:      "PublicCompany",
+				Authority: "FACTSET",
+				AuthValue: "000C7F-E",
+				PrefLabel: "Apple, Inc.",
+				NAICSIndustryClassifications: []s3.NAICSIndustryClassification{
+					{
+						UUID: "25c3be2a-15e0-434e-aaa9-ca067e70ae11",
+						Rank: 1,
+					},
+					{
+						UUID: "c9cae3ee-a804-4001-8046-02e714e1fa5b",
+						Rank: 2,
+					},
+					{
+						UUID: "7f0134c1-606a-4d12-a455-661cc4b0bfac",
+						Rank: 3,
+					},
+					{
+						UUID: "c35b851c-d185-40bd-967c-2403084920b3",
+						Rank: 4,
+					},
+				},
+			},
+			{
+				UUID:      "Organisation_WithNAICSCodes_Smartlogic_UUID",
+				Type:      "PublicCompany",
+				Authority: "Smartlogic",
+				AuthValue: "000C7F-E",
+				PrefLabel: "Apple, Inc.",
+			},
+		},
+	}
+	c, tid, err := svc.GetConcordedConcept(context.Background(), "Organisation_WithNAICSCodes_Smartlogic_UUID", "")
+	sort.Strings(c.FormerNames)
+	sort.Strings(c.Aliases)
+	sort.Strings(expectedConcept.FormerNames)
+	sort.Strings(expectedConcept.Aliases)
+	assert.NoError(t, err)
+	assert.Equal(t, "tid_736", tid)
+	assert.Equal(t, expectedConcept, c)
+}
+
 func TestAggregateService_GetConcordedConcept_BoardRole(t *testing.T) {
 	svc, _, _, _, _, _, _ := setupTestService(200, payload)
 	expectedConcept := ConcordedConcept{
@@ -1594,6 +1666,44 @@ func setupTestServiceWithTimeout(clientStatusCode int, writerResponse string, ti
 					Type:               "NAICSIndustryClassification",
 				},
 			},
+			"Organisation_WithNAICSCodes_Factset_UUID": {
+				transactionID: "tid_735",
+				concept: s3.Concept{
+					UUID:      "Organisation_WithNAICSCodes_Factset_UUID",
+					Type:      "PublicCompany",
+					Authority: "FACTSET",
+					AuthValue: "000C7F-E",
+					PrefLabel: "Apple, Inc.",
+					NAICSIndustryClassifications: []s3.NAICSIndustryClassification{
+						{
+							UUID: "25c3be2a-15e0-434e-aaa9-ca067e70ae11",
+							Rank: 1,
+						},
+						{
+							UUID: "c9cae3ee-a804-4001-8046-02e714e1fa5b",
+							Rank: 2,
+						},
+						{
+							UUID: "7f0134c1-606a-4d12-a455-661cc4b0bfac",
+							Rank: 3,
+						},
+						{
+							UUID: "c35b851c-d185-40bd-967c-2403084920b3",
+							Rank: 4,
+						},
+					},
+				},
+			},
+			"Organisation_WithNAICSCodes_Smartlogic_UUID": {
+				transactionID: "tid_736",
+				concept: s3.Concept{
+					UUID:      "Organisation_WithNAICSCodes_Smartlogic_UUID",
+					Type:      "PublicCompany",
+					Authority: "Smartlogic",
+					AuthValue: "000C7F-E",
+					PrefLabel: "Apple, Inc.",
+				},
+			},
 		},
 	}
 	conceptsQueue := &mockSQSClient{
@@ -1692,6 +1802,16 @@ func setupTestServiceWithTimeout(clientStatusCode int, writerResponse string, ti
 				concordances.ConcordanceRecord{
 					UUID:      "99309d51-8969-4a1e-8346-d51f1981479b",
 					Authority: "TME",
+				},
+			},
+			"Organisation_WithNAICSCodes_Smartlogic_UUID": {
+				{
+					UUID:      "Organisation_WithNAICSCodes_Smartlogic_UUID",
+					Authority: "Smartlogic",
+				},
+				{
+					UUID:      "Organisation_WithNAICSCodes_Factset_UUID",
+					Authority: "FACTSET",
 				},
 			},
 		},

--- a/s3/model.go
+++ b/s3/model.go
@@ -6,6 +6,11 @@ type MembershipRole struct {
 	TerminationDate string `json:"terminationDate,omitempty"`
 }
 
+type NAICSIndustryClassification struct {
+	UUID string `json:"uuid,omitempty"`
+	Rank int    `json:"rank,omitempty"`
+}
+
 type Concept struct {
 	// Required fields
 	UUID      string `json:"uuid,omitempty"`
@@ -43,22 +48,23 @@ type Concept struct {
 	PersonUUID       string           `json:"personUUID,omitempty"`
 	TerminationDate  string           `json:"terminationDate,omitempty"`
 	// Organisation
-	CountryCode                string   `json:"countryCode,omitempty"`
-	CountryOfRisk              string   `json:"countryOfRisk,omitempty"`
-	CountryOfIncorporation     string   `json:"countryOfIncorporation,omitempty"`
-	CountryOfOperations        string   `json:"countryOfOperations,omitempty"`
-	CountryOfRiskUUID          string   `json:"countryOfRiskUUID,omitempty"`
-	CountryOfIncorporationUUID string   `json:"countryOfIncorporationUUID,omitempty"`
-	CountryOfOperationsUUID    string   `json:"countryOfOperationsUUID,omitempty"`
-	FormerNames                []string `json:"formerNames,omitempty"`
-	TradeNames                 []string `json:"tradeNames,omitempty"`
-	LeiCode                    string   `json:"leiCode,omitempty"`
-	ParentOrganisation         string   `json:"parentOrganisation,omitempty"`
-	PostalCode                 string   `json:"postalCode,omitempty"`
-	ProperName                 string   `json:"properName,omitempty"`
-	ShortName                  string   `json:"shortName,omitempty"`
-	YearFounded                int      `json:"yearFounded,omitempty"`
-	IsDeprecated               bool     `json:"isDeprecated,omitempty"`
+	CountryCode                  string                        `json:"countryCode,omitempty"`
+	CountryOfRisk                string                        `json:"countryOfRisk,omitempty"`
+	CountryOfIncorporation       string                        `json:"countryOfIncorporation,omitempty"`
+	CountryOfOperations          string                        `json:"countryOfOperations,omitempty"`
+	CountryOfRiskUUID            string                        `json:"countryOfRiskUUID,omitempty"`
+	CountryOfIncorporationUUID   string                        `json:"countryOfIncorporationUUID,omitempty"`
+	CountryOfOperationsUUID      string                        `json:"countryOfOperationsUUID,omitempty"`
+	FormerNames                  []string                      `json:"formerNames,omitempty"`
+	TradeNames                   []string                      `json:"tradeNames,omitempty"`
+	LeiCode                      string                        `json:"leiCode,omitempty"`
+	ParentOrganisation           string                        `json:"parentOrganisation,omitempty"`
+	PostalCode                   string                        `json:"postalCode,omitempty"`
+	ProperName                   string                        `json:"properName,omitempty"`
+	ShortName                    string                        `json:"shortName,omitempty"`
+	YearFounded                  int                           `json:"yearFounded,omitempty"`
+	IsDeprecated                 bool                          `json:"isDeprecated,omitempty"`
+	NAICSIndustryClassifications []NAICSIndustryClassification `json:"naicsIndustryClassifications,omitempty"`
 	// Location
 	ISO31661 string `json:"iso31661,omitempty"`
 	// IndustryClassification


### PR DESCRIPTION
# Description

## What

Handle `naicsIndustryClassification` field from document store. The structure of the field allows multiple codes attached to the same organisation as well as having rank info.
Feedback on the normalised store field structure is welcome

## Why

https://financialtimes.atlassian.net/browse/UPPSF-1943

## Anything, in particular, you'd like to highlight to reviewers

On dev you can test with `Apple, Inc.` `2384fa7a-d514-3d6a-a0ea-3a711f66d0d8`

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
