### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Aggregate Concept Transformer
 
 A service that aggregates the information from all concept data providers and forwards it to the writer services for persistence in the concept stores.
@@ -8,7 +12,7 @@ aggregate-concept-transformer
 
 ## Primary URL
 
-<https://upp-prod-delivery-glb.upp.ft.com/__aggregate-concept-transformer/>
+https://upp-prod-delivery-glb.upp.ft.com/__aggregate-concept-transformer/
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- elitsa.pavlova
-- ivan.nikolov
-- kalin.arsov
-- miroslav.gatsanoga
-- marina.chompalova
 
 ## Host Platform
 
@@ -51,13 +38,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- concepts-rw-neo4j
-- concordances-rw-neo4j
-- up-crwes
-- upp-concept-events-queue
-- varnish-purger
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -96,6 +89,14 @@ Manual
 
 If the new release does not change the way messages are consumed, transformed or sent it is safe to deploy it without cluster failover.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -109,8 +110,8 @@ To rotate credentials you need to login to a particular cluster and update varni
 
 Service in UPP K8S delivery clusters:
 
-- Delivery-Prod-EU health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=aggregate-concept-transformer>
-- Delivery-Prod-US health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=aggregate-concept-transformer>
+*   Delivery-Prod-EU health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=aggregate-concept-transformer>
+*   Delivery-Prod-US health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=aggregate-concept-transformer>
 
 ## First Line Troubleshooting
 

--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -38,19 +38,6 @@ No
 
 No
 
-<!-- Placeholder - remove HTML comment markers to activate
-## Can Download Personal Data
-Choose Yes or No
-
-...or delete this placeholder if not applicable to this system
--->
-
-<!-- Placeholder - remove HTML comment markers to activate
-## Can Contact Individuals
-Choose Yes or No
-
-...or delete this placeholder if not applicable to this system
--->
 
 ## Failover Architecture Type
 
@@ -88,14 +75,6 @@ Manual
 ## Release Details
 
 If the new release does not change the way messages are consumed, transformed or sent it is safe to deploy it without cluster failover.
-
-<!-- Placeholder - remove HTML comment markers to activate
-## Heroku Pipeline Name
-Enter descriptive text satisfying the following:
-This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
-
-...or delete this placeholder if not applicable to this system
--->
 
 ## Key Management Process Type
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/aggregate-concept-transformer/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **aggregate-concept-transformer** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **aggregate-concept-transformer** system in [Biz Ops](https://biz-ops.in.ft.com/System/aggregate-concept-transformer).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
