### PR TITLE
Feature/uppsf 2646 enable readonly mode

### DIFF
--- a/concept/service_test.go
+++ b/concept/service_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/Financial-Times/aggregate-concept-transformer/concordances"
 	"github.com/Financial-Times/aggregate-concept-transformer/s3"
 	"github.com/Financial-Times/aggregate-concept-transformer/sqs"
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -1835,6 +1836,7 @@ func setupTestServiceWithTimeout(clientStatusCode int, writerResponse string, ti
 		feedback,
 		done,
 		timeout,
+		false,
 	)
 
 	feedback <- true

--- a/main.go
+++ b/main.go
@@ -246,6 +246,9 @@ func main() {
 		done := make(chan struct{})
 
 		maxWorkers := runtime.GOMAXPROCS(0) + 1
+		if *isReadOnly {
+			maxWorkers = 0
+		}
 		requestTimeout := time.Second * time.Duration(*httpTimeout)
 		svc := concept.NewService(
 			s3Client,

--- a/sqs/client.go
+++ b/sqs/client.go
@@ -3,11 +3,10 @@ package sqs
 import (
 	"context"
 	"encoding/json"
-	"regexp"
-	"strings"
-
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 
 	fthealth "github.com/Financial-Times/go-fthealth/v1_1"
 	"github.com/Financial-Times/go-logger"


### PR DESCRIPTION
# Description

## What

Implement a way to setup the service in ReadOnly mode, that depends only on S3 and concordances-rw-neo4j.

## Why

This will enable us to create tester deployment of the service in order to test new ontology functionality.

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
