### PR TITLE
Implement specific 'Relationships' model for concept relationships

### DIFF
--- a/ontology/config.go
+++ b/ontology/config.go
@@ -115,6 +115,13 @@ func (cfg Config) IsPropValueValid(propName string, val interface{}) bool {
 	}
 }
 
+func (cfg Config) GetRelationshipUUIDKey(label string) string {
+	if label == "HAS_ROLE" {
+		return "membershipRoleUUID"
+	}
+	return "uuid"
+}
+
 var config Config
 
 //go:embed config.yaml

--- a/ontology/relationship.go
+++ b/ontology/relationship.go
@@ -1,0 +1,215 @@
+package ontology
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Relationship struct {
+	UUID       string                 `json:"uuid"`
+	Label      string                 `json:"label"`
+	Properties map[string]interface{} `json:"properties"`
+}
+
+type Relationships []Relationship
+
+func (r *Relationships) MarshalJSON() ([]byte, error) {
+	result := map[string]interface{}{}
+	for _, rel := range *r {
+		if rel.UUID == "" {
+			continue
+		}
+
+		cfg, ok := GetConfig().Relationships[rel.Label]
+		if !ok {
+			continue
+		}
+		relAny := writeRelationshipsToAny(cfg, rel, result[cfg.ConceptField])
+		result[cfg.ConceptField] = relAny
+	}
+
+	return json.Marshal(result)
+}
+
+func (r *Relationships) UnmarshalJSON(bytes []byte) error {
+	oldMap := map[string]interface{}{}
+	if err := json.Unmarshal(bytes, &oldMap); err != nil {
+		return err
+	}
+	for label, cfg := range GetConfig().Relationships {
+		if _, ok := oldMap[cfg.ConceptField]; !ok {
+			continue
+		}
+
+		val := oldMap[cfg.ConceptField]
+
+		rel, err := readRelationshipsFromAny(label, cfg, val)
+		if err != nil {
+			return err
+		}
+		*r = append(*r, rel...)
+	}
+	return nil
+}
+
+func writeRelationshipsToAny(cfg RelationshipConfig, rel Relationship, prev interface{}) interface{} {
+	if cfg.OneToOne {
+		return rel.UUID
+	}
+
+	if prev == nil {
+		if len(cfg.Properties) == 0 {
+			return []string{rel.UUID}
+		}
+
+		relProps := rel.Properties
+		uuidKey := GetConfig().GetRelationshipUUIDKey(rel.Label)
+		relProps[uuidKey] = rel.UUID
+
+		return []map[string]interface{}{relProps}
+	}
+
+	if len(cfg.Properties) == 0 {
+		relUUIDs := prev.([]string)
+		relUUIDs = append(relUUIDs, rel.UUID)
+		return relUUIDs
+	}
+
+	relProps := rel.Properties
+	uuidKey := GetConfig().GetRelationshipUUIDKey(rel.Label)
+	relProps[uuidKey] = rel.UUID
+
+	rels := prev.([]map[string]interface{})
+	rels = append(rels, relProps)
+	return rels
+}
+
+func readRelationshipsFromAny(label string, cfg RelationshipConfig, val interface{}) (Relationships, error) {
+	if cfg.OneToOne {
+		uuid, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast '%v' to string for relationship '%s' uuid", val, label)
+		}
+		return Relationships{{UUID: uuid, Label: label}}, nil
+	}
+
+	result := Relationships{}
+	valSlice, ok := val.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to cast '%v' to slice for relationships '%s' ", val, label)
+	}
+
+	if len(cfg.Properties) == 0 {
+		for _, v := range valSlice {
+			uuid, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("failed to cast '%v' to string for relationships '%s' uuid", v, label)
+			}
+			result = append(result, Relationship{UUID: uuid, Label: label})
+		}
+		return result, nil
+	}
+
+	for _, v := range valSlice {
+		// extract uuid
+		uuid, props, ok := extractUUIDAndProps(label, v)
+		if !ok {
+			continue // TODO: change to error?
+		}
+		props, err := readRelationshipProps(cfg, props)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read relationship '%s' props: %w", label, err)
+		}
+		result = append(result, Relationship{UUID: uuid, Label: label, Properties: props})
+	}
+	return result, nil
+}
+
+func extractUUIDAndProps(label string, v interface{}) (string, map[string]interface{}, bool) {
+	props, ok := v.(map[string]interface{})
+	if !ok {
+		return "", nil, false
+	}
+	uuidKey := GetConfig().GetRelationshipUUIDKey(label)
+	uuidI, ok := props[uuidKey]
+	if !ok {
+		return "", nil, false
+	}
+	uuid, ok := uuidI.(string)
+	if !ok {
+		return "", nil, false
+	}
+	delete(props, uuidKey)
+	return uuid, props, true
+}
+
+func readRelationshipProps(cfg RelationshipConfig, props map[string]interface{}) (map[string]interface{}, error) {
+	result := map[string]interface{}{}
+	for field, fieldType := range cfg.Properties {
+		var v interface{}
+		val, ok := props[field]
+		if !ok {
+			continue
+		}
+
+		switch fieldType {
+		case "date":
+			if v, ok = toString(val); !ok {
+				return nil, InvalidPropValueError(field, v)
+			}
+		case "string":
+			if v, ok = toString(val); !ok {
+				return nil, InvalidPropValueError(field, v)
+			}
+		case "[]string":
+			if v, ok = toStringSlice(val); !ok {
+				return nil, InvalidPropValueError(field, v)
+			}
+		case "int":
+			if v, ok = toInt(val); !ok {
+				return nil, InvalidPropValueError(field, v)
+			}
+		default:
+			return nil,
+				fmt.Errorf("unsupported field type '%s' for prop '%s': %w", fieldType, field, ErrUnknownProperty)
+		}
+		result[field] = v
+	}
+	return result, nil
+}
+
+func toString(val interface{}) (string, bool) {
+	str, ok := val.(string)
+	return str, ok
+}
+
+func toInt(val interface{}) (int, bool) {
+	switch v := val.(type) {
+	case int:
+		return v, true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+func toStringSlice(val interface{}) ([]string, bool) {
+	if vs, ok := val.([]string); ok {
+		return vs, ok
+	}
+	vs, ok := val.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	var result []string
+	for _, v := range vs {
+		if str, ok := v.(string); ok {
+			result = append(result, str)
+		}
+	}
+	if len(result) != len(vs) {
+		return nil, false
+	}
+	return result, true
+}

--- a/ontology/transform/transform_test.go
+++ b/ontology/transform/transform_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/Financial-Times/aggregate-concept-transformer/ontology"
 	"github.com/Financial-Times/aggregate-concept-transformer/ontology/transform"
@@ -31,9 +33,13 @@ func TestToNewSourceConcept(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if !cmp.Equal(source, sourceTransfomed) {
-		diff := cmp.Diff(source, sourceTransfomed)
+	opts := cmp.Options{
+		cmpopts.SortSlices(func(l, r ontology.Relationship) bool {
+			return strings.Compare(l.Label, r.Label) > 0
+		}),
+	}
+	if !cmp.Equal(source, sourceTransfomed, opts) {
+		diff := cmp.Diff(source, sourceTransfomed, opts)
 		t.Fatal(diff)
 	}
 }


### PR DESCRIPTION
# Description

## What

- Add new Relationship type that holds concept relationships
- Copy code for reading and writing relationships from/to interface{} from the current ontology implementation
- Implement mechanism for serialising and deserialising relationships to json correctly. Preserving the flat json messaging format.

## Why

This is a separate PR to #79 to help with the review process.

## Anything, in particular, you'd like to highlight to reviewers

The logic behind this refactoring is that we want to have concept property that stored the relationships for each concept of type 'Relationship'. Basically copy the functionality from current ontology lib implementation.
But at the same time we want to keep the messaging format as they were before the ontology extraction. As in all properties and relationships were in a flat json structure.

To accomplish these goals we leverage custom json marshal/unmarshal and substructures.

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
