### PR TITLE
Feature/uppsf 3099 use ontology models

### DIFF
--- a/concept/handlers.go
+++ b/concept/handlers.go
@@ -20,8 +20,13 @@ import (
 	"github.com/Financial-Times/aggregate-concept-transformer/ontology/transform"
 )
 
+type aggregateService interface {
+	ProcessMessage(ctx context.Context, UUID string, bookmark string) error
+	GetConcordedConcept(ctx context.Context, UUID string, bookmark string) (transform.OldAggregatedConcept, string, error)
+}
+
 type AggregateConceptHandler struct {
-	svc            Service
+	svc            aggregateService
 	requestTimeout time.Duration
 }
 
@@ -29,7 +34,7 @@ type httpClient interface {
 	Do(req *http.Request) (resp *http.Response, err error)
 }
 
-func NewHandler(svc Service, timeout time.Duration) AggregateConceptHandler {
+func NewHandler(svc aggregateService, timeout time.Duration) AggregateConceptHandler {
 	return AggregateConceptHandler{svc: svc, requestTimeout: timeout}
 }
 

--- a/concept/handlers.go
+++ b/concept/handlers.go
@@ -17,12 +17,12 @@ import (
 	"github.com/Financial-Times/http-handlers-go/httphandlers"
 	status "github.com/Financial-Times/service-status-go/httphandlers"
 
-	"github.com/Financial-Times/aggregate-concept-transformer/ontology/transform"
+	"github.com/Financial-Times/aggregate-concept-transformer/ontology"
 )
 
 type aggregateService interface {
 	ProcessMessage(ctx context.Context, UUID string, bookmark string) error
-	GetConcordedConcept(ctx context.Context, UUID string, bookmark string) (transform.OldAggregatedConcept, string, error)
+	GetConcordedConcept(ctx context.Context, UUID string, bookmark string) (ontology.NewAggregatedConcept, string, error)
 }
 
 type AggregateConceptHandler struct {
@@ -59,9 +59,9 @@ func (h *AggregateConceptHandler) GetHandler(w http.ResponseWriter, r *http.Requ
 	json.NewEncoder(w).Encode(concept)
 }
 
-func (h *AggregateConceptHandler) getConcordedConcept(ctx context.Context, UUID string) (transform.OldAggregatedConcept, string, error) {
+func (h *AggregateConceptHandler) getConcordedConcept(ctx context.Context, UUID string) (ontology.NewAggregatedConcept, string, error) {
 	type concordedTransaction struct {
-		Concept       transform.OldAggregatedConcept
+		Concept       ontology.NewAggregatedConcept
 		TransactionID string
 		Err           error
 	}

--- a/concept/handlers_test.go
+++ b/concept/handlers_test.go
@@ -142,19 +142,12 @@ type MockService struct {
 	err           error
 }
 
-func NewMockService(concepts map[string]transform.OldAggregatedConcept, notifications []sqs.ConceptUpdate, healthchecks []fthealth.Check, err error) Service {
+func NewMockService(concepts map[string]transform.OldAggregatedConcept, notifications []sqs.ConceptUpdate, healthchecks []fthealth.Check, err error) *MockService {
 	return &MockService{
 		concepts:      concepts,
 		notifications: notifications,
 		healthchecks:  healthchecks,
 		err:           err,
-	}
-}
-
-func (s *MockService) ListenForNotifications(ctx context.Context, workerId int) {
-	for _, n := range s.notifications {
-		//nolint:errcheck
-		s.ProcessMessage(ctx, n.UUID, n.Bookmark)
 	}
 }
 

--- a/concept/healthcheck.go
+++ b/concept/healthcheck.go
@@ -5,9 +5,13 @@ import (
 	"github.com/Financial-Times/service-status-go/gtg"
 )
 
+type healthChecker interface {
+	Healthchecks() []fthealth.Check
+}
+
 type HealthService struct {
 	config *config
-	svc    Service
+	svc    healthChecker
 	Checks []fthealth.Check
 }
 
@@ -18,7 +22,7 @@ type config struct {
 	description   string
 }
 
-func NewHealthService(svc Service, appSystemCode string, appName string, port int, description string) *HealthService {
+func NewHealthService(svc healthChecker, appSystemCode string, appName string, port int, description string) *HealthService {
 	service := &HealthService{
 		config: &config{
 			appSystemCode: appSystemCode,

--- a/concept/service.go
+++ b/concept/service.go
@@ -262,10 +262,11 @@ func (s *AggregateService) ProcessMessage(ctx context.Context, UUID string, book
 		personUUID, err := getPersonUUIDFromConcept(concordedConcept)
 		if err != nil {
 			logger.WithTransactionID(transactionID).WithUUID(concordedConcept.PrefUUID).WithError(err).Errorf("Concept couldn't be purged from Varnish cache")
-		}
-		err = sendToPurger(ctx, s.httpClient, s.varnishPurgerAddress, []string{personUUID}, "Person", s.typesToPurgeFromPublicEndpoints, transactionID)
-		if err != nil {
-			logger.WithTransactionID(transactionID).WithUUID(personUUID).Errorf("Concept couldn't be purged from Varnish cache")
+		} else {
+			err = sendToPurger(ctx, s.httpClient, s.varnishPurgerAddress, []string{personUUID}, "Person", s.typesToPurgeFromPublicEndpoints, transactionID)
+			if err != nil {
+				logger.WithTransactionID(transactionID).WithUUID(personUUID).WithError(err).Errorf("Concept couldn't be purged from Varnish cache")
+			}
 		}
 	}
 

--- a/concept/service.go
+++ b/concept/service.go
@@ -38,13 +38,6 @@ var irregularConceptTypePaths = map[string]string{
 	"NAICSIndustryClassification": "industry-classifications",
 }
 
-type Service interface {
-	ListenForNotifications(ctx context.Context, workerID int)
-	ProcessMessage(ctx context.Context, UUID string, bookmark string) error
-	GetConcordedConcept(ctx context.Context, UUID string, bookmark string) (transform.OldAggregatedConcept, string, error)
-	Healthchecks() []fthealth.Check
-}
-
 type systemHealth struct {
 	sync.RWMutex
 	healthy  bool

--- a/concept/service_test.go
+++ b/concept/service_test.go
@@ -144,7 +144,7 @@ func TestAggregateService_ProcessConceptUpdate_ContextTimeout(t *testing.T) {
 func TestAggregateService_GetConcordedConcept_NoConcordance(t *testing.T) {
 	svc, _, _, _, _, _, _ := setupTestService(200, payload)
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "99247059-04ec-3abb-8693-a0b8951fdcab", "")
+	c, tid, err := getConceptFromService(svc, context.Background(), "99247059-04ec-3abb-8693-a0b8951fdcab", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_123", tid)
 	assert.Equal(t, "Test Concept", c.PrefLabel)
@@ -157,7 +157,7 @@ func TestAggregateService_GetConcordedConcept_CancelContext(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, tid, err := svc.GetConcordedConcept(ctx, "99247059-04ec-3abb-8693-a0b8951fdcab", "")
+	_, tid, err := getConceptFromService(svc, ctx, "99247059-04ec-3abb-8693-a0b8951fdcab", "")
 	assert.EqualError(t, err, "context canceled")
 	assert.Equal(t, "", tid)
 }
@@ -187,8 +187,7 @@ func TestAggregateService_GetConcordedConcept_Location(t *testing.T) {
 			},
 		},
 	}
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "f8024a12-2d71-4f0e-996d-bcbc07df3921", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "f8024a12-2d71-4f0e-996d-bcbc07df3921", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_999", tid)
@@ -223,8 +222,7 @@ func TestAggregateService_GetConcordedConcept_ManagedLocationCountry(t *testing.
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "FR_ML_UUID", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "FR_ML_UUID", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_112", tid)
@@ -266,9 +264,7 @@ func TestAggregateService_GetConcordedConcept_SmartlogicCountry(t *testing.T) {
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "BE_SL_UUID", "")
-
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "BE_SL_UUID", "")
 	sort.Strings(expectedConcept.Aliases)
 	sort.Slice(c.SourceRepresentations, func(i, j int) bool {
 		return c.SourceRepresentations[i].UUID < c.SourceRepresentations[j].UUID
@@ -345,8 +341,7 @@ func TestAggregateService_GetConcordedConcept_TMEConcordance(t *testing.T) {
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "28090964-9997-4bc2-9638-7a11135aaff9", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "28090964-9997-4bc2-9638-7a11135aaff9", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_456", tid)
@@ -417,8 +412,7 @@ func TestAggregateService_GetConcordedConcept_DeprecatedSmartlogic(t *testing.T)
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "28090964-9997-4bc2-9638-7a11135aaf10", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "28090964-9997-4bc2-9638-7a11135aaf10", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_456", tid)
@@ -487,8 +481,7 @@ func TestAggregateService_GetConcordedConcept_SupersededConcept(t *testing.T) {
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "28090964-9997-4bc2-9638-7a11135aaf11", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "28090964-9997-4bc2-9638-7a11135aaf11", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_456", tid)
@@ -527,7 +520,7 @@ func TestAggregateService_GetConcordedConcept_ConceptWithRelationships(t *testin
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "781bb463-dc53-4d3e-9d49-c48dc4cf6d55", "")
+	c, tid, err := getConceptFromService(svc, context.Background(), "781bb463-dc53-4d3e-9d49-c48dc4cf6d55", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_633", tid)
 	assert.Equal(t, expectedConcept, c)
@@ -556,8 +549,7 @@ func TestAggregateService_GetConcordedConcept_FinancialInstrument(t *testing.T) 
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "6562674e-dbfa-4cb0-85b2-41b0948b7cc2", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "6562674e-dbfa-4cb0-85b2-41b0948b7cc2", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_630", tid)
@@ -628,9 +620,7 @@ func TestAggregateService_GetConcordedConcept_Organisation(t *testing.T) {
 			},
 		},
 	}
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "c28fa0b4-4245-11e8-842f-0ed5f89f718b", "")
-	sort.Strings(c.FormerNames)
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "c28fa0b4-4245-11e8-842f-0ed5f89f718b", "")
 	sort.Strings(expectedConcept.FormerNames)
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
@@ -710,9 +700,7 @@ func TestAggregateService_GetConcordedConcept_PublicCompany(t *testing.T) {
 			},
 		},
 	}
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "a141f50f-31d7-4f89-8143-eec971e54ba8", "")
-	sort.Strings(c.FormerNames)
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "a141f50f-31d7-4f89-8143-eec971e54ba8", "")
 	sort.Strings(expectedConcept.FormerNames)
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
@@ -782,9 +770,7 @@ func TestAggregateService_GetConcordedConcept_PublicCompany_WithNAICSCodes(t *te
 			},
 		},
 	}
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "Organisation_WithNAICSCodes_Smartlogic_UUID", "")
-	sort.Strings(c.FormerNames)
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "Organisation_WithNAICSCodes_Smartlogic_UUID", "")
 	sort.Strings(expectedConcept.FormerNames)
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
@@ -810,8 +796,7 @@ func TestAggregateService_GetConcordedConcept_BoardRole(t *testing.T) {
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "344fdb1d-0585-31f7-814f-b478e54dbe1f", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "344fdb1d-0585-31f7-814f-b478e54dbe1f", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_631", tid)
@@ -836,8 +821,7 @@ func TestAggregateService_GetConcordedConcept_LoneTME(t *testing.T) {
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "99309d51-8969-4a1e-8346-d51f1981479b", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "99309d51-8969-4a1e-8346-d51f1981479b", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_439", tid)
@@ -896,8 +880,7 @@ func TestAggregateService_GetConcordedConcept_Memberships(t *testing.T) {
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "87cda39a-e354-3dfb-b28a-b9a04887577b", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "87cda39a-e354-3dfb-b28a-b9a04887577b", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_632", tid)
@@ -924,8 +907,7 @@ func TestAggregateService_GetConcordedConcept_IndustryClassification(t *testing.
 		},
 	}
 
-	c, tid, err := svc.GetConcordedConcept(context.Background(), "IndustryClassification_Smartlogic_UUID", "")
-	sort.Strings(c.Aliases)
+	c, tid, err := getConceptFromService(svc, context.Background(), "IndustryClassification_Smartlogic_UUID", "")
 	sort.Strings(expectedConcept.Aliases)
 	assert.NoError(t, err)
 	assert.Equal(t, "tid_359", tid)
@@ -1230,6 +1212,19 @@ func TestResolveConceptType(t *testing.T) {
 
 	company := resolveConceptType("PublicCompany")
 	assert.Equal(t, "organisations", company)
+}
+
+// getConceptFromService is a wrapper function for getting concepts from the service
+//
+// nolint: revive, unparam
+// silence specific linters for this function as we don't care about them.
+// context-as-argument: context.Context should be the first parameter of a function (revive)
+// `getConceptFromService` - `bookmark` always receives `""` (unparam)
+func getConceptFromService(svc *AggregateService, ctx context.Context, conceptUUID string, bookmark string) (transform.OldAggregatedConcept, string, error) {
+	c, tid, err := svc.GetConcordedConcept(ctx, conceptUUID, bookmark)
+	sort.Strings(c.Aliases)
+	sort.Strings(c.FormerNames)
+	return c, tid, err
 }
 
 func setupTestService(clientStatusCode int, writerResponse string) (*AggregateService, *mockS3Client, *mockSQSClient, *mockSQSClient, *mockKinesisStreamClient, chan bool, chan struct{}) {

--- a/concept/service_test.go
+++ b/concept/service_test.go
@@ -1226,9 +1226,16 @@ func TestResolveConceptType(t *testing.T) {
 // `getConceptFromService` - `bookmark` always receives `""` (unparam)
 func getConceptFromService(svc *AggregateService, ctx context.Context, conceptUUID string, bookmark string) (transform.OldAggregatedConcept, string, error) {
 	c, tid, err := svc.GetConcordedConcept(ctx, conceptUUID, bookmark)
-	sort.Strings(c.Aliases)
-	sort.Strings(c.FormerNames)
-	return c, tid, err
+	if err != nil {
+		return transform.OldAggregatedConcept{}, "", err
+	}
+	old, err := transform.ToOldAggregateConcept(c)
+	if err != nil {
+		return transform.OldAggregatedConcept{}, "", err
+	}
+	sort.Strings(old.Aliases)
+	sort.Strings(old.FormerNames)
+	return old, tid, nil
 }
 
 func setupTestService(clientStatusCode int, writerResponse string) (*AggregateService, *mockS3Client, *mockSQSClient, *mockSQSClient, *mockKinesisStreamClient, chan bool, chan struct{}) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Financial-Times/go-logger"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/Financial-Times/aggregate-concept-transformer/concept"
+	"github.com/Financial-Times/aggregate-concept-transformer/concordances"
+	"github.com/Financial-Times/aggregate-concept-transformer/ontology"
+	"github.com/Financial-Times/aggregate-concept-transformer/sqs"
+
+	fthealth "github.com/Financial-Times/go-fthealth/v1_1"
+)
+
+// service integration test
+
+func TestAggregateService_GetConceptHandler(t *testing.T) {
+	logger.InitLogger("aggregate-concept-transformer-testing", "panic")
+
+	expected := readAggregateConceptFixture(t, "testdata/aggregated-concept.json")
+	sources := readSourceConceptFixture(t, "testdata/source-concepts.json")
+
+	// generic http server that will handle all aggregate service requests
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.Contains(request.RequestURI, "concordances") {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// make sure that s3 will return the correct sources based on the setup data
+	s3Concepts := map[string]ontology.NewConcept{}
+	for _, s := range sources {
+		s3Concepts[s.UUID] = s
+	}
+	s3 := s3Mock{
+		concepts: s3Concepts,
+	}
+	// sqs and kinesis are currently not used in this test so no specifics
+	sqsClient := &sqsMock{}
+	ksClient := &kinesisMock{}
+	concordancesClient, err := concordances.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timeout := time.Second * 30
+	feedback := make(chan bool)
+	done := make(chan struct{})
+	defer close(feedback)
+	defer close(done)
+
+	service := concept.NewService(s3, sqsClient, sqsClient, concordancesClient, ksClient, server.URL+"/neo4j", server.URL+"/elastic", server.URL+"/varnish", []string{""}, server.Client(), feedback, done, timeout, true)
+	handler := concept.NewHandler(service, timeout)
+
+	m := handler.RegisterHandlers(concept.NewHealthService(service, "", "", 8080, ""), false, feedback)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://localhost:8080/concept/"+expected.PrefUUID, nil)
+
+	m.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal(http.StatusText(resp.StatusCode))
+	}
+
+	var actual ontology.NewAggregatedConcept
+	err = json.NewDecoder(resp.Body).Decode(&actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compareAggregateConcepts(t, expected, actual)
+}
+
+func compareAggregateConcepts(t *testing.T, expected, actual ontology.NewAggregatedConcept) {
+	t.Helper()
+	opts := cmp.Options{
+		cmpopts.SortSlices(func(l, r ontology.Relationship) bool {
+			return strings.Compare(l.Label, r.Label) > 0
+		}),
+		cmpopts.SortSlices(func(l, r string) bool {
+			return strings.Compare(l, r) > 0
+		}),
+	}
+	if !cmp.Equal(expected, actual, opts) {
+		diff := cmp.Diff(expected, actual, opts)
+		t.Fatal(diff)
+	}
+}
+
+// great place to use generics for readSourceConceptFixture and readAggregateConceptFixture
+func readSourceConceptFixture(t *testing.T, filename string) []ontology.NewConcept {
+	t.Helper()
+
+	f, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var result []ontology.NewConcept
+	err = json.NewDecoder(f).Decode(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func readAggregateConceptFixture(t *testing.T, filename string) ontology.NewAggregatedConcept {
+	t.Helper()
+
+	f, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var result ontology.NewAggregatedConcept
+	err = json.NewDecoder(f).Decode(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+type s3Mock struct {
+	concepts map[string]ontology.NewConcept
+}
+
+func (s s3Mock) GetConceptAndTransactionID(ctx context.Context, UUID string) (bool, ontology.NewConcept, string, error) {
+	concept, ok := s.concepts[UUID]
+	if !ok {
+		return false, ontology.NewConcept{}, "", errors.New("not found")
+	}
+	return true, concept, "tid_test", nil
+}
+
+func (s s3Mock) Healthcheck() fthealth.Check {
+	return fthealth.Check{}
+}
+
+type sqsMock struct {
+}
+
+func (s sqsMock) ListenAndServeQueue(ctx context.Context) []sqs.ConceptUpdate {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s sqsMock) SendEvents(ctx context.Context, messages []sqs.Event) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s sqsMock) RemoveMessageFromQueue(ctx context.Context, receiptHandle *string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s sqsMock) Healthcheck() fthealth.Check {
+	return fthealth.Check{}
+}
+
+type kinesisMock struct {
+}
+
+func (k kinesisMock) AddRecordToStream(ctx context.Context, updatedConcept []byte, conceptType string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (k kinesisMock) Healthcheck() fthealth.Check {
+	return fthealth.Check{}
+}

--- a/ontology/concordedConcept.go
+++ b/ontology/concordedConcept.go
@@ -33,7 +33,7 @@ type AdditionalConcordedFields struct {
 	IsDeprecated bool `json:"isDeprecated,omitempty"`
 }
 
-func (cc *NewAggregatedConcept) MarshalJSON() ([]byte, error) {
+func (cc NewAggregatedConcept) MarshalJSON() ([]byte, error) {
 	req, err := mappify(cc.RequiredConcordedFields)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (cc *NewAggregatedConcept) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	rels, err := mappify(&cc.Relationships)
+	rels, err := mappify(cc.Relationships)
 	if err != nil {
 		return nil, err
 	}

--- a/ontology/concordedConcept.go
+++ b/ontology/concordedConcept.go
@@ -12,12 +12,12 @@ type NewAggregatedConcept struct {
 
 type RequiredConcordedFields struct {
 	// Required fields
-	PrefUUID       string `json:"prefUUID"`
-	PrefLabel      string `json:"prefLabel"`
-	Type           string `json:"type"`
+	PrefUUID       string `json:"prefUUID,omitempty"`
+	PrefLabel      string `json:"prefLabel,omitempty"`
+	Type           string `json:"type,omitempty"`
 	AggregatedHash string `json:"aggregateHash,omitempty"`
 	// Source representations
-	SourceRepresentations []NewConcept `json:"sourceRepresentations"`
+	SourceRepresentations []NewConcept `json:"sourceRepresentations,omitempty"`
 }
 
 type AdditionalConcordedFields struct {

--- a/ontology/relationship.go
+++ b/ontology/relationship.go
@@ -13,9 +13,9 @@ type Relationship struct {
 
 type Relationships []Relationship
 
-func (r *Relationships) MarshalJSON() ([]byte, error) {
+func (r Relationships) MarshalJSON() ([]byte, error) {
 	result := map[string]interface{}{}
-	for _, rel := range *r {
+	for _, rel := range r {
 		if rel.UUID == "" {
 			continue
 		}
@@ -63,6 +63,10 @@ func writeRelationshipsToAny(cfg RelationshipConfig, rel Relationship, prev inte
 		}
 
 		relProps := rel.Properties
+		if relProps == nil {
+			// relProps should never be nil, but if it is, ensure that we will not panic.
+			relProps = map[string]interface{}{}
+		}
 		uuidKey := GetConfig().GetRelationshipUUIDKey(rel.Label)
 		relProps[uuidKey] = rel.UUID
 

--- a/ontology/sourceConcept.go
+++ b/ontology/sourceConcept.go
@@ -10,11 +10,11 @@ type NewConcept struct {
 }
 
 type RequiredSourceFields struct {
-	UUID              string `json:"uuid"`
-	Type              string `json:"type"`
-	PrefLabel         string `json:"prefLabel"`
-	Authority         string `json:"authority"`
-	AuthorityValue    string `json:"authorityValue"`
+	UUID              string `json:"uuid,omitempty"`
+	Type              string `json:"type,omitempty"`
+	PrefLabel         string `json:"prefLabel,omitempty"`
+	Authority         string `json:"authority,omitempty"`
+	AuthorityValue    string `json:"authorityValue,omitempty"`
 	LastModifiedEpoch int    `json:"lastModifiedEpoch,omitempty"`
 	Hash              string `json:"hash,omitempty"`
 }

--- a/ontology/sourceConcept.go
+++ b/ontology/sourceConcept.go
@@ -32,7 +32,7 @@ type AdditionalSourceFields struct {
 	IsDeprecated bool `json:"isDeprecated,omitempty"`
 }
 
-func (sc *NewConcept) MarshalJSON() ([]byte, error) {
+func (sc NewConcept) MarshalJSON() ([]byte, error) {
 	req, err := mappify(sc.RequiredSourceFields)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (sc *NewConcept) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	rels, err := mappify(&sc.Relationships)
+	rels, err := mappify(sc.Relationships)
 	if err != nil {
 		return nil, err
 	}

--- a/s3/client.go
+++ b/s3/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Financial-Times/go-logger"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 
@@ -19,8 +20,14 @@ import (
 )
 
 type Client struct {
-	s3         *s3.S3
+	s3         s3API
 	bucketName string
+}
+
+type s3API interface {
+	GetObjectWithContext(ctx aws.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error)
+	HeadObjectWithContext(ctx aws.Context, input *s3.HeadObjectInput, opts ...request.Option) (*s3.HeadObjectOutput, error)
+	HeadBucket(input *s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
 }
 
 func NewClient(bucketName string, awsRegion string) (*Client, error) {

--- a/s3/client.go
+++ b/s3/client.go
@@ -79,6 +79,7 @@ func (c *Client) GetConceptAndTransactionID(ctx context.Context, UUID string) (b
 		logger.WithError(err).WithUUID(UUID).Error("Error retrieving concept from S3")
 		return false, ontology.NewConcept{}, "", err
 	}
+	defer resp.Body.Close()
 
 	getHeadersParams := &s3.HeadObjectInput{
 		Bucket: aws.String(c.bucketName),

--- a/s3/client_test.go
+++ b/s3/client_test.go
@@ -1,0 +1,122 @@
+package s3
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/Financial-Times/aggregate-concept-transformer/ontology/transform"
+)
+
+func TestClient_GetConceptAndTransactionID(t *testing.T) {
+	testBucket := "testBucket"
+	testKey := "testKey"
+	testTID := "tid_test"
+	testConceptFixture := "testdata/test-concept.json"
+	expected := readOldConceptFixture(t, testConceptFixture)
+
+	client := &Client{
+		s3: &mockS3API{
+			t:                  t,
+			testBucket:         testBucket,
+			testKey:            testKey,
+			testTID:            testTID,
+			testConceptFixture: testConceptFixture,
+		},
+		bucketName: testBucket,
+	}
+
+	has, concept, tid, err := client.GetConceptAndTransactionID(context.Background(), testKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
+		t.Error("expected s3 to have the concept")
+	}
+	if tid != testTID {
+		t.Errorf("expect tid %v, got %v", testTID, tid)
+	}
+
+	if !cmp.Equal(expected, concept) {
+		diff := cmp.Diff(expected, concept)
+		t.Errorf("concept mismatch: %s", diff)
+	}
+}
+
+func readOldConceptFixture(t *testing.T, filename string) transform.OldConcept {
+	t.Helper()
+	f, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := transform.OldConcept{}
+	err = json.NewDecoder(f).Decode(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+type mockS3API struct {
+	t                  *testing.T
+	testBucket         string
+	testKey            string
+	testTID            string
+	testConceptFixture string
+}
+
+func (m *mockS3API) GetObjectWithContext(ctx aws.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error) {
+	m.t.Helper()
+	if input.Bucket == nil {
+		m.t.Fatal("expect bucket to not be nil")
+	}
+	if e, a := m.testBucket, *input.Bucket; e != a {
+		m.t.Errorf("expect bucket %v, got %v", e, a)
+	}
+	if input.Key == nil {
+		m.t.Fatal("expect key to not be nil")
+	}
+	if e, a := m.testKey, *input.Key; e != a {
+		m.t.Errorf("expect key %v, got %v", e, a)
+	}
+
+	conceptFile, err := os.Open(m.testConceptFixture)
+	if err != nil {
+		m.t.Fatal(err)
+	}
+
+	return &s3.GetObjectOutput{
+		Body: conceptFile,
+	}, nil
+}
+
+func (m *mockS3API) HeadObjectWithContext(ctx aws.Context, input *s3.HeadObjectInput, opts ...request.Option) (*s3.HeadObjectOutput, error) {
+	m.t.Helper()
+	if input.Bucket == nil {
+		m.t.Fatal("expect bucket to not be nil")
+	}
+	if e, a := m.testBucket, *input.Bucket; e != a {
+		m.t.Errorf("expect bucket %v, got %v", e, a)
+	}
+	if input.Key == nil {
+		m.t.Fatal("expect key to not be nil")
+	}
+	if e, a := m.testKey, *input.Key; e != a {
+		m.t.Errorf("expect key %v, got %v", e, a)
+	}
+	return &s3.HeadObjectOutput{
+		Metadata: map[string]*string{
+			"Transaction_id": aws.String(m.testTID),
+		},
+	}, nil
+}
+
+func (m *mockS3API) HeadBucket(input *s3.HeadBucketInput) (*s3.HeadBucketOutput, error) {
+	panic("implement me")
+}

--- a/s3/client_test.go
+++ b/s3/client_test.go
@@ -43,7 +43,12 @@ func TestClient_GetConceptAndTransactionID(t *testing.T) {
 		t.Errorf("expect tid %v, got %v", testTID, tid)
 	}
 
-	if !cmp.Equal(expected, concept) {
+	actual, err := transform.ToOldSourceConcept(concept)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cmp.Equal(expected, actual) {
 		diff := cmp.Diff(expected, concept)
 		t.Errorf("concept mismatch: %s", diff)
 	}

--- a/s3/testdata/test-concept.json
+++ b/s3/testdata/test-concept.json
@@ -1,0 +1,35 @@
+{
+  "uuid": "b4ddd5a5-0b6c-4dc2-bb75-3eb40c1b05ed",
+  "type": "PublicCompany",
+  "prefLabel": "The New York Times Co.",
+  "authority": "FACTSET",
+  "authorityValue": "000R9L-E",
+  "aliases": [
+    "The New York Times",
+    "The New York Times Co.",
+    "The New York Times Company"
+  ],
+  "emailAddress": "help@nytimes.com",
+  "countryCode": "US",
+  "countryOfRisk": "US",
+  "countryOfIncorporation": "US",
+  "countryOfOperations": "US",
+  "countryOfRiskUUID": "3e2eb1c1-7ecd-4600-8cbb-c02ba53ced4b",
+  "countryOfIncorporationUUID": "3e2eb1c1-7ecd-4600-8cbb-c02ba53ced4b",
+  "countryOfOperationsUUID": "3e2eb1c1-7ecd-4600-8cbb-c02ba53ced4b",
+  "leiCode": "529900J1WEMMIW7BOH57",
+  "postalCode": "10018",
+  "properName": "The New York Times Co.",
+  "shortName": "The New York Times",
+  "yearFounded": 1851,
+  "naicsIndustryClassifications": [
+    {
+      "uuid": "49da878c-67ce-4343-9a09-a4a767e584a2",
+      "rank": 1
+    },
+    {
+      "uuid": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
+      "rank": 2
+    }
+  ]
+}

--- a/testdata/aggregated-concept.json
+++ b/testdata/aggregated-concept.json
@@ -1,0 +1,40 @@
+{
+  "prefUUID": "74b5ac98-c19a-3ecb-99c4-5daab97d761f",
+  "prefLabel": "Scarlett Retail Group Ltd.",
+  "type": "Organisation",
+  "aliases": [
+    "Scarlett Retail Group Ltd."
+  ],
+  "countryOfIncorporation": "GB",
+  "countryOfOperations": "GB",
+  "properName": "Scarlett Retail Group Ltd.",
+  "naicsIndustryClassifications": [
+    {
+      "uuid": "afc85187-7af3-4e85-9be2-ef7e1e9eec91",
+      "rank": 1
+    }
+  ],
+  "sourceRepresentations": [
+    {
+      "uuid": "74b5ac98-c19a-3ecb-99c4-5daab97d761f",
+      "type": "Organisation",
+      "prefLabel": "Scarlett Retail Group Ltd.",
+      "authority": "FACTSET",
+      "authorityValue": "05K3SY-E",
+      "aliases": [
+        "Scarlett Retail Group Ltd."
+      ],
+      "countryOfIncorporation": "GB",
+      "countryOfOperations": "GB",
+      "countryOfIncorporationUUID": "6b683eff-56c3-43d9-acfc-7511d974fc01",
+      "countryOfOperationsUUID": "6b683eff-56c3-43d9-acfc-7511d974fc01",
+      "properName": "Scarlett Retail Group Ltd.",
+      "naicsIndustryClassifications": [
+        {
+          "uuid": "afc85187-7af3-4e85-9be2-ef7e1e9eec91",
+          "rank": 1
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/source-concepts.json
+++ b/testdata/source-concepts.json
@@ -1,0 +1,23 @@
+[
+  {
+    "uuid": "74b5ac98-c19a-3ecb-99c4-5daab97d761f",
+    "type": "Organisation",
+    "properName": "Scarlett Retail Group Ltd.",
+    "prefLabel": "Scarlett Retail Group Ltd.",
+    "authority": "FACTSET",
+    "authorityValue": "05K3SY-E",
+    "aliases": [
+      "Scarlett Retail Group Ltd."
+    ],
+    "countryOfIncorporation": "GB",
+    "countryOfOperations": "GB",
+    "countryOfIncorporationUUID": "6b683eff-56c3-43d9-acfc-7511d974fc01",
+    "countryOfOperationsUUID": "6b683eff-56c3-43d9-acfc-7511d974fc01",
+    "naicsIndustryClassifications": [
+      {
+        "uuid": "afc85187-7af3-4e85-9be2-ef7e1e9eec91",
+        "rank": 1
+      }
+    ]
+  }
+]


### PR DESCRIPTION
# Description

## What

Refactor aggregate-concept-transformer service to use ontology concept models instead of the old static concept models.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3099

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
