### PR TITLE
Feature/uppsf 4624 allow reading from external concept bucket

### DIFF
--- a/concept/handlers.go
+++ b/concept/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	ontology "github.com/Financial-Times/cm-graph-ontology"
@@ -39,9 +40,13 @@ func NewHandler(svc aggregateService, timeout time.Duration) AggregateConceptHan
 func (h *AggregateConceptHandler) GetHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	UUID := vars["uuid"]
+	publication := vars["publication"]
 	w.Header().Set("Content-Type", "application/json")
 	ctx, cancel := context.WithTimeout(r.Context(), h.requestTimeout)
 	defer cancel()
+	if publication != "" {
+		UUID = strings.Join([]string{publication, UUID}, "-")
+	}
 
 	concept, transactionID, err := h.getConcordedConcept(ctx, UUID)
 

--- a/concept/handlers.go
+++ b/concept/handlers.go
@@ -40,7 +40,7 @@ func NewHandler(svc aggregateService, timeout time.Duration) AggregateConceptHan
 func (h *AggregateConceptHandler) GetHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	UUID := vars["uuid"]
-	publication := vars["publication"]
+	publication := r.URL.Query().Get("publication")
 	w.Header().Set("Content-Type", "application/json")
 	ctx, cancel := context.WithTimeout(r.Context(), h.requestTimeout)
 	defer cancel()

--- a/concept/handlers_test.go
+++ b/concept/handlers_test.go
@@ -64,7 +64,7 @@ func TestHandlers(t *testing.T) {
 				},
 			},
 		},
-		"Get Concept - Not Found": {
+		"Get External Concept - Not Found": {
 			method:     "GET",
 			url:        "/concept/f7fd05ea-9999-47c0-9be9-c99dd84d0097?publication=8e6c705e-1132-42a2-8db0-c295e29e8658",
 			resultCode: 500,
@@ -73,7 +73,7 @@ func TestHandlers(t *testing.T) {
 			},
 			err: errors.New("Canonical concept not found in S3"),
 		},
-		"Get External Concept - Not Found": {
+		"Get Concept - Not Found": {
 			method:     "GET",
 			url:        "/concept/f7fd05ea-9999-47c0-9be9-c99dd84d0097",
 			resultCode: 500,

--- a/concept/handlers_test.go
+++ b/concept/handlers_test.go
@@ -49,7 +49,31 @@ func TestHandlers(t *testing.T) {
 				},
 			},
 		},
+		"Get External Concept - Success": {
+			method:     "GET",
+			url:        "/concept/f7fd05ea-9999-47c0-9be9-c99dd84d0097?publication=8e6c705e-1132-42a2-8db0-c295e29e8658",
+			resultCode: 200,
+			resultJSONBody: map[string]interface{}{
+				"prefUUID":  "f7fd05ea-9999-47c0-9be9-c99dd84d0097",
+				"prefLabel": "TestConcept",
+			},
+			concepts: map[string]transform.OldAggregatedConcept{
+				"8e6c705e-1132-42a2-8db0-c295e29e8658-f7fd05ea-9999-47c0-9be9-c99dd84d0097": {
+					PrefUUID:  "f7fd05ea-9999-47c0-9be9-c99dd84d0097",
+					PrefLabel: "TestConcept",
+				},
+			},
+		},
 		"Get Concept - Not Found": {
+			method:     "GET",
+			url:        "/concept/f7fd05ea-9999-47c0-9be9-c99dd84d0097?publication=8e6c705e-1132-42a2-8db0-c295e29e8658",
+			resultCode: 500,
+			resultJSONBody: map[string]interface{}{
+				"message": "Canonical concept not found in S3",
+			},
+			err: errors.New("Canonical concept not found in S3"),
+		},
+		"Get External Concept - Not Found": {
 			method:     "GET",
 			url:        "/concept/f7fd05ea-9999-47c0-9be9-c99dd84d0097",
 			resultCode: 500,

--- a/concept/s3_mock_test.go
+++ b/concept/s3_mock_test.go
@@ -2,6 +2,7 @@ package concept
 
 import (
 	"context"
+	"strings"
 
 	ontology "github.com/Financial-Times/cm-graph-ontology"
 	"github.com/Financial-Times/cm-graph-ontology/transform"
@@ -19,12 +20,17 @@ type mockS3Client struct {
 	callsMocked bool
 }
 
-func (s *mockS3Client) GetConceptAndTransactionID(ctx context.Context, UUID string) (bool, ontology.NewConcept, string, error) {
+func (s *mockS3Client) GetConceptAndTransactionID(ctx context.Context, publication string, UUID string) (bool, ontology.NewConcept, string, error) {
 	if s.callsMocked {
 		s.Called(UUID)
 	}
 
-	c, ok := s.concepts[UUID]
+	key := UUID
+	if publication != "" {
+		key = strings.Join([]string{publication, UUID}, "/")
+	}
+
+	c, ok := s.concepts[key]
 	if !ok {
 		return false, ontology.NewConcept{}, "", s.err
 	}

--- a/concept/service.go
+++ b/concept/service.go
@@ -83,7 +83,7 @@ func (r *systemHealth) processChannel() {
 }
 
 type normalisedClient interface {
-	GetConceptAndTransactionID(ctx context.Context, UUID string) (bool, ontology.NewConcept, string, error)
+	GetConceptAndTransactionID(ctx context.Context, publication string, UUID string) (bool, ontology.NewConcept, string, error)
 	Healthcheck() fthealth.Check
 }
 
@@ -376,7 +376,7 @@ func (s *AggregateService) getConcordedConcept(ctx context.Context, UUID string,
 	var err error
 	sourceConcepts := []ontology.NewConcept{}
 
-	cleanedUUID, externalAuthority, err := extractIdentifiersFromKey(UUID)
+	cleanedUUID, publication, err := extractIdentifiersFromKey(UUID)
 	if err != nil {
 		return ontology.NewAggregatedConcept{}, "", err
 	}
@@ -399,10 +399,10 @@ func (s *AggregateService) getConcordedConcept(ctx context.Context, UUID string,
 		for _, conc := range concordanceRecords {
 			var found bool
 			var sourceConcept ontology.NewConcept
-			if externalAuthority != "" {
-				found, sourceConcept, transactionID, err = s.externalNormalisedStore.GetConceptAndTransactionID(ctx, strings.Join([]string{externalAuthority, conc.UUID}, "-"))
+			if publication != "" {
+				found, sourceConcept, transactionID, err = s.externalNormalisedStore.GetConceptAndTransactionID(ctx, publication, conc.UUID)
 			} else {
-				found, sourceConcept, transactionID, err = s.nStore.GetConceptAndTransactionID(ctx, conc.UUID)
+				found, sourceConcept, transactionID, err = s.nStore.GetConceptAndTransactionID(ctx, "", conc.UUID)
 			}
 
 			if err != nil {
@@ -426,10 +426,10 @@ func (s *AggregateService) getConcordedConcept(ctx context.Context, UUID string,
 	var foundPrimary bool
 	if primaryAuthority != "" {
 		canonicalConcept := bucketedConcordances[primaryAuthority][0]
-		if externalAuthority != "" {
-			foundPrimary, primaryConcept, transactionID, err = s.externalNormalisedStore.GetConceptAndTransactionID(ctx, strings.Join([]string{externalAuthority, canonicalConcept.UUID}, "-"))
+		if publication != "" {
+			foundPrimary, primaryConcept, transactionID, err = s.externalNormalisedStore.GetConceptAndTransactionID(ctx, publication, canonicalConcept.UUID)
 		} else {
-			foundPrimary, primaryConcept, transactionID, err = s.nStore.GetConceptAndTransactionID(ctx, canonicalConcept.UUID)
+			foundPrimary, primaryConcept, transactionID, err = s.nStore.GetConceptAndTransactionID(ctx, "", canonicalConcept.UUID)
 		}
 
 		if err != nil {

--- a/concept/service.go
+++ b/concept/service.go
@@ -30,15 +30,18 @@ const (
 	conceptsAPIEnpoint = "/concepts"
 )
 
-var irregularConceptTypePaths = map[string]string{
-	"AlphavilleSeries":            "alphaville-series",
-	"BoardRole":                   "membership-roles",
-	"Dummy":                       "dummies",
-	"Person":                      "people",
-	"PublicCompany":               "organisations",
-	"NAICSIndustryClassification": "industry-classifications",
-	"FTAnIIndustryClassification": "industry-classifications",
-}
+var (
+	irregularConceptTypePaths = map[string]string{
+		"AlphavilleSeries":            "alphaville-series",
+		"BoardRole":                   "membership-roles",
+		"Dummy":                       "dummies",
+		"Person":                      "people",
+		"PublicCompany":               "organisations",
+		"NAICSIndustryClassification": "industry-classifications",
+		"FTAnIIndustryClassification": "industry-classifications",
+	}
+	UUIDMatcher = regexp.MustCompile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+)
 
 type systemHealth struct {
 	sync.RWMutex
@@ -86,6 +89,7 @@ type normalisedClient interface {
 
 type AggregateService struct {
 	nStore                          normalisedClient
+	externalNormalisedStore         normalisedClient
 	concordances                    concordances.Client
 	conceptUpdatesSqs               sqs.Client
 	eventsSns                       sns.Client
@@ -102,6 +106,7 @@ type AggregateService struct {
 
 func NewService(
 	S3Client normalisedClient,
+	ExternalS3Client normalisedClient,
 	conceptUpdatesSQSClient sqs.Client,
 	eventsSNSClient sns.Client,
 	concordancesClient concordances.Client,
@@ -126,6 +131,7 @@ func NewService(
 
 	return &AggregateService{
 		nStore:                          S3Client,
+		externalNormalisedStore:         ExternalS3Client,
 		concordances:                    concordancesClient,
 		conceptUpdatesSqs:               conceptUpdatesSQSClient,
 		eventsSns:                       eventsSNSClient,
@@ -370,11 +376,15 @@ func (s *AggregateService) getConcordedConcept(ctx context.Context, UUID string,
 	var err error
 	sourceConcepts := []ontology.NewConcept{}
 
-	concordedRecords, err := s.concordances.GetConcordance(ctx, UUID, bookmark)
+	cleanedUUID, externalAuthority, err := extractIdentifiersFromKey(UUID)
 	if err != nil {
 		return ontology.NewAggregatedConcept{}, "", err
 	}
-	logger.WithField("UUID", UUID).Debugf("Returned concordance record: %v", concordedRecords)
+	concordedRecords, err := s.concordances.GetConcordance(ctx, cleanedUUID, bookmark)
+	if err != nil {
+		return ontology.NewAggregatedConcept{}, "", err
+	}
+	logger.WithField("UUID", cleanedUUID).Debugf("Returned concordance record: %v", concordedRecords)
 
 	bucketedConcordances, primaryAuthority, err := bucketConcordances(concordedRecords)
 	if err != nil {
@@ -389,14 +399,19 @@ func (s *AggregateService) getConcordedConcept(ctx context.Context, UUID string,
 		for _, conc := range concordanceRecords {
 			var found bool
 			var sourceConcept ontology.NewConcept
-			found, sourceConcept, transactionID, err = s.nStore.GetConceptAndTransactionID(ctx, conc.UUID)
+			if externalAuthority != "" {
+				found, sourceConcept, transactionID, err = s.externalNormalisedStore.GetConceptAndTransactionID(ctx, strings.Join([]string{externalAuthority, conc.UUID}, "-"))
+			} else {
+				found, sourceConcept, transactionID, err = s.nStore.GetConceptAndTransactionID(ctx, conc.UUID)
+			}
+
 			if err != nil {
 				return ontology.NewAggregatedConcept{}, "", err
 			}
 
 			if !found {
 				//we should let the concorded concept to be written as a "Thing"
-				logger.WithField("UUID", UUID).Warn(fmt.Sprintf("Source concept %s not found in S3", conc))
+				logger.WithField("UUID", cleanedUUID).Warn(fmt.Sprintf("Source concept %s not found in S3", conc))
 				sourceConcept.Authority = authority
 				sourceConcept.AuthorityValue = conc.AuthorityValue
 				sourceConcept.UUID = conc.UUID
@@ -411,12 +426,17 @@ func (s *AggregateService) getConcordedConcept(ctx context.Context, UUID string,
 	var foundPrimary bool
 	if primaryAuthority != "" {
 		canonicalConcept := bucketedConcordances[primaryAuthority][0]
-		foundPrimary, primaryConcept, transactionID, err = s.nStore.GetConceptAndTransactionID(ctx, canonicalConcept.UUID)
+		if externalAuthority != "" {
+			foundPrimary, primaryConcept, transactionID, err = s.externalNormalisedStore.GetConceptAndTransactionID(ctx, strings.Join([]string{externalAuthority, canonicalConcept.UUID}, "-"))
+		} else {
+			foundPrimary, primaryConcept, transactionID, err = s.nStore.GetConceptAndTransactionID(ctx, canonicalConcept.UUID)
+		}
+
 		if err != nil {
 			return ontology.NewAggregatedConcept{}, "", err
 		} else if !foundPrimary {
 			err = fmt.Errorf("canonical concept %s not found in S3", canonicalConcept.UUID)
-			logger.WithField("UUID", UUID).Error(err.Error())
+			logger.WithField("UUID", cleanedUUID).Error(err.Error())
 			return ontology.NewAggregatedConcept{}, "", err
 		}
 	}
@@ -453,6 +473,19 @@ func (s *AggregateService) Healthchecks() []fthealth.Check {
 		checks = append(checks, s.kinesis.Healthcheck())
 	}
 	return checks
+}
+
+func extractIdentifiersFromKey(uuid string) (string, string, error) {
+	matches := UUIDMatcher.FindAllString(uuid, 2)
+	if matches == nil {
+		return "", "", fmt.Errorf("error while extracting identificators from key: %s", uuid)
+	}
+
+	if len(matches) > 1 {
+		return matches[1], matches[0], nil
+	}
+
+	return matches[0], "", nil
 }
 
 func sendToPurger(ctx context.Context, client httpClient, baseURL string, conceptUUIDs []string, conceptType string, conceptTypesWithPublicEndpoints []string, tid string) error {

--- a/concept/service.go
+++ b/concept/service.go
@@ -28,6 +28,7 @@ import (
 const (
 	thingsAPIEndpoint  = "/things"
 	conceptsAPIEnpoint = "/concepts"
+	lengthOfUUID       = 36
 )
 
 var (
@@ -227,6 +228,9 @@ func (s *AggregateService) ProcessMessage(ctx context.Context, UUID string, book
 	if err != nil {
 		return err
 	}
+
+	// Extract only the real UUID when publication is present, safe as the uuid is alway at least 36 characters
+	UUID = UUID[len(UUID)-lengthOfUUID:]
 	if concordedConcept.PrefUUID != UUID {
 		logger.WithTransactionID(transactionID).WithUUID(UUID).Infof("Requested concept %s is source node for canonical concept %s", UUID, concordedConcept.PrefUUID)
 	}

--- a/concept/service.go
+++ b/concept/service.go
@@ -467,6 +467,7 @@ func (s *AggregateService) getConcordedConcept(ctx context.Context, UUID string,
 func (s *AggregateService) Healthchecks() []fthealth.Check {
 	checks := []fthealth.Check{
 		s.nStore.Healthcheck(),
+		s.externalNormalisedStore.Healthcheck(),
 		s.concordances.Healthcheck(),
 	}
 	if !s.readOnly {

--- a/concept/service_test.go
+++ b/concept/service_test.go
@@ -79,7 +79,7 @@ const (
 
 func TestNewService(t *testing.T) {
 	svc, _, _, _, _, _, _ := setupTestService(200, payload)
-	assert.Equal(t, 7, len(svc.Healthchecks()))
+	assert.Equal(t, 8, len(svc.Healthchecks()))
 }
 
 func TestAggregateService_ListenForNotifications(t *testing.T) {

--- a/concept/service_test.go
+++ b/concept/service_test.go
@@ -112,7 +112,7 @@ func TestAggregateService_ListenForNotifications_ProcessConceptNotInS3(t *testin
 	mockSqsClient.conceptsQueue[receiptHandle] = nonExistingConcept
 	go svc.ListenForNotifications(context.Background(), 1)
 	time.Sleep(500 * time.Microsecond)
-	hasIt, _, _, err := s3mock.GetConceptAndTransactionID(context.Background(), nonExistingConcept)
+	hasIt, _, _, err := s3mock.GetConceptAndTransactionID(context.Background(), "", nonExistingConcept)
 	assert.Equal(t, hasIt, false)
 	assert.NoError(t, err)
 	err = mockSqsClient.RemoveMessageFromQueue(context.Background(), &receiptHandle)
@@ -1760,7 +1760,7 @@ func setupTestServiceWithTimeout(clientStatusCode int, writerResponse string, ti
 			transactionID string
 			concept       transform.OldConcept
 		}{
-			"929da855-c1ba-4576-89c1-5c3ec9e4c6ef-f3633e04-2ee3-48ce-8081-37734dab3fdc": {
+			"929da855-c1ba-4576-89c1-5c3ec9e4c6ef/f3633e04-2ee3-48ce-8081-37734dab3fdc": {
 				transactionID: "tid_358",
 				concept: transform.OldConcept{
 					UUID:           "f3633e04-2ee3-48ce-8081-37734dab3fdc",

--- a/helm/aggregate-concept-transformer/app-configs/aggregate-concept-transformer_eks_delivery.yaml
+++ b/helm/aggregate-concept-transformer/app-configs/aggregate-concept-transformer_eks_delivery.yaml
@@ -8,5 +8,6 @@ env:
   LOG_LEVEL: info
   REQUEST_LOGGING_ON: true
   BUCKET_REGION: "eu-west-1"
+  EXTERNAL_BUCKET_REGION: "eu-west-1"
 waitTime: 20
 httpTimeout: 15

--- a/helm/aggregate-concept-transformer/templates/deployment.yaml
+++ b/helm/aggregate-concept-transformer/templates/deployment.yaml
@@ -61,6 +61,11 @@ spec:
             secretKeyRef:
               name: doppler-global-secrets
               key: CONCEPTS_S3_BUCKET
+        - name: EXTERNAL_BUCKET_NAME
+          valueFrom:
+            secretKeyRef:
+              name: doppler-global-secrets
+              key: EXTERNAL_CONCEPTS_S3_BUCKET
         - name: CONCEPTS_QUEUE_URL
           valueFrom:
             secretKeyRef:

--- a/main_test.go
+++ b/main_test.go
@@ -148,7 +148,7 @@ type s3Mock struct {
 	concepts map[string]ontology.NewConcept
 }
 
-func (s s3Mock) GetConceptAndTransactionID(ctx context.Context, UUID string) (bool, ontology.NewConcept, string, error) {
+func (s s3Mock) GetConceptAndTransactionID(ctx context.Context, publication string, UUID string) (bool, ontology.NewConcept, string, error) {
 	concept, ok := s.concepts[UUID]
 	if !ok {
 		return false, ontology.NewConcept{}, "", errors.New("not found")

--- a/main_test.go
+++ b/main_test.go
@@ -50,6 +50,9 @@ func TestAggregateService_GetConceptHandler(t *testing.T) {
 	s3 := s3Mock{
 		concepts: s3Concepts,
 	}
+	externalS3Mock := s3Mock{
+		concepts: s3Concepts,
+	}
 	// sqs and kinesis are currently not used in this test so no specifics
 	sqsClient := &sqsMock{}
 	snsClient := &snsMock{}
@@ -65,7 +68,7 @@ func TestAggregateService_GetConceptHandler(t *testing.T) {
 	defer close(feedback)
 	defer close(done)
 
-	service := concept.NewService(s3, sqsClient, snsClient, concordancesClient, ksClient, server.URL+"/neo4j", server.URL+"/elastic", server.URL+"/varnish", []string{""}, server.Client(), feedback, done, timeout, true)
+	service := concept.NewService(s3, externalS3Mock, sqsClient, snsClient, concordancesClient, ksClient, server.URL+"/neo4j", server.URL+"/elastic", server.URL+"/varnish", []string{""}, server.Client(), feedback, done, timeout, true)
 	handler := concept.NewHandler(service, timeout)
 
 	m := handler.RegisterHandlers(concept.NewHealthService(service, "", "", 8080, ""), false, feedback)

--- a/s3/client.go
+++ b/s3/client.go
@@ -70,10 +70,15 @@ func NewClient(bucketName string, awsRegion string) (*Client, error) {
 	}, err
 }
 
-func (c *Client) GetConceptAndTransactionID(ctx context.Context, UUID string) (bool, ontology.NewConcept, string, error) {
+func (c *Client) GetConceptAndTransactionID(ctx context.Context, publication string, UUID string) (bool, ontology.NewConcept, string, error) {
+	key := getKey(UUID)
+	if publication != "" {
+		key = strings.Join([]string{publication, key}, "/")
+	}
+
 	getObjectParams := &s3.GetObjectInput{
 		Bucket: aws.String(c.bucketName),
-		Key:    aws.String(getKey(UUID)),
+		Key:    aws.String(key),
 	}
 
 	resp, err := c.s3.GetObjectWithContext(ctx, getObjectParams)
@@ -90,7 +95,7 @@ func (c *Client) GetConceptAndTransactionID(ctx context.Context, UUID string) (b
 
 	getHeadersParams := &s3.HeadObjectInput{
 		Bucket: aws.String(c.bucketName),
-		Key:    aws.String(getKey(UUID)),
+		Key:    aws.String(key),
 	}
 	ho, err := c.s3.HeadObjectWithContext(ctx, getHeadersParams)
 	if err != nil {

--- a/s3/client_test.go
+++ b/s3/client_test.go
@@ -32,7 +32,7 @@ func TestClient_GetConceptAndTransactionID(t *testing.T) {
 		bucketName: testBucket,
 	}
 
-	has, concept, tid, err := client.GetConceptAndTransactionID(context.Background(), testKey)
+	has, concept, tid, err := client.GetConceptAndTransactionID(context.Background(), "", testKey)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Description

## What

Allow aggregate concept transformer to read external concepts from the new S3 bucket. Modify the Get Request with publication parameter to allow reading concepts from the external concepts bucket through postman (for debugging/checking purposes).

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4624)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
